### PR TITLE
feat: load and save game session info to dynamodb

### DIFF
--- a/game/models.py
+++ b/game/models.py
@@ -176,9 +176,10 @@ class GameSession:
         self.total_annotations = total_annotations
 
     def abandon_game(self):
-        """Mark the game session as abandoned"""
-        self.status = "abandoned"
-        self.end_time = datetime.now()
+        """Mark the game session as abandoned (if not already ended)"""
+        if self.status != "completed":
+            self.status = "abandoned"
+            self.end_time = datetime.now()
 
     def to_dynamodb_item(self) -> dict:
         """Convert user to dictionary representation"""

--- a/game/models.py
+++ b/game/models.py
@@ -96,3 +96,17 @@ class User:
             "role": self.role,
             "join_date": self.join_date.isoformat() if self.join_date else None,
         }
+    
+    @staticmethod
+    def from_dynamodb_item(user_data: dict) -> "User":
+        """Create a User object from a DynamoDB item"""
+
+        join_date = user_data.get("join_date")
+        if join_date:
+            join_date = datetime.fromisoformat(join_date)
+        return User(
+            username=user_data.get("PartitionKey", ""),
+            email=user_data.get("email", ""),
+            role=user_data.get("role", ""),
+            join_date=join_date,
+        )

--- a/game/models.py
+++ b/game/models.py
@@ -165,11 +165,20 @@ class GameSession:
         self.start_time = datetime.now()
         self.total_annotations = 0
 
+    def update_total_annotations(self, total_annotations: int):
+        """Update the total number of annotations made in the game session"""
+        self.total_annotations = total_annotations
+
     def end_game(self, total_annotations: int):
         """Mark the game session as ended"""
         self.status = "completed"
         self.end_time = datetime.now()
         self.total_annotations = total_annotations
+
+    def abandon_game(self):
+        """Mark the game session as abandoned"""
+        self.status = "abandoned"
+        self.end_time = datetime.now()
 
     def to_dynamodb_item(self) -> dict:
         """Convert user to dictionary representation"""

--- a/game/models.py
+++ b/game/models.py
@@ -157,3 +157,15 @@ class GameSession:
             self.session_id = session_id
         else:
             self.session_id = "SESSION_" + uuid4().hex
+
+    def start_game(self):
+        """Mark the game session as started"""
+        self.status = "active"
+        self.start_time = datetime.now()
+        self.total_annotations = 0
+
+    def end_game(self, total_annotations: int):
+        """Mark the game session as ended"""
+        self.status = "completed"
+        self.end_time = datetime.now()
+        self.total_annotations = total_annotations

--- a/game/models.py
+++ b/game/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4
 
+
 class Page:
     """Class to represent a page in the app"""
 
@@ -96,7 +97,7 @@ class User:
             "role": self.role,
             "join_date": self.join_date.isoformat() if self.join_date else None,
         }
-    
+
     @staticmethod
     def from_dynamodb_item(user_data: dict) -> "User":
         """Create a User object from a DynamoDB item"""
@@ -207,6 +208,6 @@ class GameSession:
             start_time=start_time,
             end_time=end_time,
             total_annotations=session_data.get("total_annotations"),
-            s3_location=session_data.get("s3_location")
+            s3_location=session_data.get("s3_location"),
         )
         return session

--- a/game/models.py
+++ b/game/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from typing import List, Optional
-
+from uuid import uuid4
 
 class Page:
     """Class to represent a page in the app"""
@@ -110,3 +110,50 @@ class User:
             role=user_data.get("role", ""),
             join_date=join_date,
         )
+
+
+class GameSession:
+    """Class to represent a game session"""
+
+    session_id: str
+    username: str
+    status: str
+    # game options (configured by user)
+    game_mode: str
+    num_rounds: int
+    time_per_round: int
+    # game stats
+    start_time: Optional[datetime]
+    end_time: Optional[datetime]
+    total_annotations: Optional[int]
+    s3_location: Optional[str]
+
+    def __init__(
+        self,
+        username: str,
+        game_mode: str,
+        num_rounds: int,
+        time_per_round: int,
+        status: str = "not_started",
+        session_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        total_annotations: Optional[int] = None,
+        s3_location: Optional[str] = None,
+    ):
+        """Initialize a GameSession instance"""
+
+        self.username = username
+        self.game_mode = game_mode
+        self.num_rounds = num_rounds
+        self.time_per_round = time_per_round
+        self.status = status
+        self.start_time = start_time
+        self.end_time = end_time
+        self.total_annotations = total_annotations
+        self.s3_location = s3_location
+
+        if session_id:
+            self.session_id = session_id
+        else:
+            self.session_id = "SESSION_" + uuid4().hex

--- a/game/models.py
+++ b/game/models.py
@@ -169,3 +169,44 @@ class GameSession:
         self.status = "completed"
         self.end_time = datetime.now()
         self.total_annotations = total_annotations
+
+    def to_dynamodb_item(self) -> dict:
+        """Convert user to dictionary representation"""
+        return {
+            # do not change the partion and sort key names
+            "PartitionKey": self.username,
+            "SortKey": self.session_id,
+            # other attributes
+            "status": self.status,
+            "game_mode": self.game_mode,
+            "num_rounds": self.num_rounds,
+            "time_per_round": self.time_per_round,
+            "start_time": self.start_time.isoformat() if self.start_time else None,
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "total_annotations": self.total_annotations,
+            "s3_location": self.s3_location,
+        }
+
+    @staticmethod
+    def from_dynamodb_item(session_data: dict) -> "GameSession":
+        """Create a GameSession object from a DynamoDB item"""
+
+        start_time = session_data.get("start_time")
+        if start_time:
+            start_time = datetime.fromisoformat(start_time)
+        end_time = session_data.get("end_time")
+        if end_time:
+            end_time = datetime.fromisoformat(end_time)
+        session = GameSession(
+            username=session_data.get("PartitionKey", ""),
+            game_mode=session_data.get("game_mode", ""),
+            num_rounds=session_data.get("num_rounds", 0),
+            time_per_round=session_data.get("time_per_round", 0),
+            status=session_data.get("status", ""),
+            session_id=session_data.get("SortKey", ""),
+            start_time=start_time,
+            end_time=end_time,
+            total_annotations=session_data.get("total_annotations"),
+            s3_location=session_data.get("s3_location")
+        )
+        return session

--- a/game/pages/account.py
+++ b/game/pages/account.py
@@ -26,8 +26,17 @@ else:
     else:
         st.text_input("Member since", value="N/A", disabled=True)
 
-    # Stub metrics - to be replaced with real data later
+    # Basic metrics
+    total_games = st.session_state.game_session_manager.count_sessions_for_user(
+        user.username
+    )
+    total_annotations = (
+        st.session_state.game_session_manager.get_total_annotations_for_user(
+            user.username
+        )
+    )
     col1, col2, col3 = st.columns(3)
-    col1.metric("Total games played", 0)
-    col2.metric("Total annotations made", 0)
+    col1.metric("Total games played", total_games)
+    col2.metric("Total annotations made", total_annotations)
+    # TODO: other metrics
     col3.metric("Average accuracy", "0%")

--- a/game/pages/game_single_player.py
+++ b/game/pages/game_single_player.py
@@ -5,10 +5,10 @@ import streamlit as st
 import streamlit.components.v1 as components
 from config import Constants, Pages
 from utils.game import (
-    save_game,
     clear_game,
     get_game_options_from_session_state,
     process_round_timer,
+    save_game,
     start_game,
     start_round,
 )
@@ -95,9 +95,7 @@ else:
     if current_round < num_rounds:
         # User has more rounds to play but still save current progress to db
         save_game(
-            total_annotations=total_num_annotations,
-            end_game=False,
-            is_abandoned=False
+            total_annotations=total_num_annotations, end_game=False, is_abandoned=False
         )
         # Display round summary and next round button
         st.info(f"You made {current_num_annotations} annotations this round.")
@@ -110,9 +108,7 @@ else:
     else:
         # User has completed all rounds. Save the game to Db
         save_game(
-            total_annotations=total_num_annotations,
-            end_game=True,
-            is_abandoned=False
+            total_annotations=total_num_annotations, end_game=True, is_abandoned=False
         )
         # Display final summary and options
         st.balloons()

--- a/game/pages/game_single_player.py
+++ b/game/pages/game_single_player.py
@@ -5,7 +5,8 @@ import streamlit as st
 import streamlit.components.v1 as components
 from config import Constants, Pages
 from utils.game import (
-    end_game,
+    save_game,
+    clear_game,
     get_game_options_from_session_state,
     process_round_timer,
     start_game,
@@ -87,22 +88,33 @@ else:
     ]
     num_rounds = GAME_OPTIONS.get("num_rounds")
     total_num_annotations = sum(
-        [
-            st.session_state.game_summary[r]["num_annotations"]
-            for r in st.session_state.game_summary
-        ]
+        summary["num_annotations"]
+        for summary in st.session_state.get("game_summary", {}).values()
     )
     st.subheader(f"Time's up for Round {current_round}/{num_rounds}!")
     if current_round < num_rounds:
+        # User has more rounds to play but still save current progress to db
+        save_game(
+            total_annotations=total_num_annotations,
+            end_game=False,
+            is_abandoned=False
+        )
+        # Display round summary and next round button
         st.info(f"You made {current_num_annotations} annotations this round.")
         with st.expander("Show current summary"):
             st.json(st.session_state.game_summary)
-        # Button to start the next round
         if st.button("Start Next Round", type="primary"):
             start_round(
                 st.session_state.current_round + 1, GAME_OPTIONS.get("time_per_round")
             )
     else:
+        # User has completed all rounds. Save the game to Db
+        save_game(
+            total_annotations=total_num_annotations,
+            end_game=True,
+            is_abandoned=False
+        )
+        # Display final summary and options
         st.balloons()
         st.success(
             f"Thank you for playing! You made a total of {total_num_annotations} annotations."
@@ -116,5 +128,5 @@ else:
         if st.button("Download Results"):
             st.info("Feature coming soon!")
         if st.button("Exit Game"):
-            end_game()
+            clear_game()
             st.switch_page(Pages.HOME.value.link)

--- a/game/pages/home.py
+++ b/game/pages/home.py
@@ -35,20 +35,21 @@ def show_game_options(game_mode: GameMode):
         step=1,
         help="How long each round will last",
     )
-    allow_movement = st.radio(
-        "Allow move",
-        options=[True, False],
-        format_func=lambda x: "Yes" if x else "No",
-        index=0,
-        help="Whether you can move around the brain during the game.",
-    )
-    allow_zoom = st.radio(
-        "Allow zoom",
-        options=[True, False],
-        format_func=lambda x: "Yes" if x else "No",
-        index=0,
-        help="Whether you can zoom in/out of the brain during the game.",
-    )
+    # Example additional options
+    # allow_movement = st.radio(
+    #     "Allow move",
+    #     options=[True, False],
+    #     format_func=lambda x: "Yes" if x else "No",
+    #     index=0,
+    #     help="Whether you can move around the brain during the game.",
+    # )
+    # allow_zoom = st.radio(
+    #     "Allow zoom",
+    #     options=[True, False],
+    #     format_func=lambda x: "Yes" if x else "No",
+    #     index=0,
+    #     help="Whether you can zoom in/out of the brain during the game.",
+    # )
     # start game button
     if st.button("Start game", use_container_width=True):
         # save game options to session state
@@ -56,8 +57,8 @@ def show_game_options(game_mode: GameMode):
             "game_mode": game_mode.label,
             "num_rounds": num_rounds,
             "time_per_round": time_per_round,
-            "allow_movement": allow_movement,
-            "allow_zoom": allow_zoom,
+            # "allow_movement": allow_movement,
+            # "allow_zoom": allow_zoom,
         }
         # redirect to the game page
         if game_mode.link is None:

--- a/game/streamlit_app.py
+++ b/game/streamlit_app.py
@@ -92,7 +92,7 @@ def create_user(role: str):
                 role=UserRoles[role].value.label,
                 join_date=datetime.now(),
             )
-            created_user = st.session_state.user_manager.create_user(user)
+            created_user = st.session_state.user_manager.upsert_user(user)
             st.session_state.role = role
             st.session_state.user = created_user
             st.switch_page(Pages.HOME.value.link)

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -42,8 +42,8 @@ class UserManager:
         print(f"Retrieved user data from dynamodb: {user_data}")
         return User.from_dynamodb_item(user_data) if user_data else None
 
-    def create_user(self, user: User) -> User:
-        """Create a new user in the database."""
+    def upsert_user(self, user: User) -> User:
+        """Add or update a user in the database."""
         user_data = user.to_dynamodb_item()
         print(f"Saving user data to dynamodb: {user_data}")
         self.db_client.put_item(user_data)
@@ -64,8 +64,8 @@ class GameSessionManager:
         print(f"Retrieved game session data from dynamodb: {session_data}")
         return GameSession.from_dynamodb_item(session_data) if session_data else None
 
-    def create_session(self, session: GameSession) -> GameSession:
-        """Create a new game session in the database."""
+    def upsert_session(self, session: GameSession) -> GameSession:
+        """Add or update a game session in the database."""
         session_data = session.to_dynamodb_item()
         print(f"Saving session data to dynamodb: {session_data}")
         self.db_client.put_item(session_data)

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import boto3
 from config import Constants
-from models import User
+from models import User, GameSession
 
 
 class DynamoDbClient:
@@ -56,14 +56,20 @@ class GameSessionManager:
     def __init__(self, db_client: DynamoDbClient):
         self.db_client = db_client
 
-    def get_session(self, session_id: str) -> dict | None:
+    def get_session(self, username: str, session_id: str) -> Optional[GameSession]:
         """Retrieve game session data by session ID."""
-        key = {"session_id": session_id}
-        return self.db_client.get_item(key)
+        # NOTE: key is a dictionary that must contain the partion and sort keys
+        key = {"PartitionKey": username, "SortKey": session_id}
+        session_data = self.db_client.get_item(key)
+        print(f"Retrieved game session data from dynamodb: {session_data}")
+        return GameSession.from_dynamodb_item(session_data) if session_data else None
 
-    def create_session(self, session_data: dict) -> None:
+    def create_session(self, session: GameSession) -> GameSession:
         """Create a new game session in the database."""
-        self.db_client.put_item(Constants.DYNAMODB_TABLE.value, session_data)
+        session_data = session.to_dynamodb_item()
+        print(f"Saving session data to dynamodb: {session_data}")
+        self.db_client.put_item(session_data)
+        return session
 
 
 def initialize_db_managers() -> tuple[UserManager, GameSessionManager]:

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import boto3
 from config import Constants
-from models import User, GameSession
+from models import GameSession, User
 
 
 class DynamoDbClient:

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -1,6 +1,6 @@
 """Utility clients for interacting with DynamoDB."""
 
-from datetime import datetime
+from typing import Optional
 
 import boto3
 from config import Constants
@@ -15,7 +15,7 @@ class DynamoDbClient:
         self._dynamodb = boto3.resource("dynamodb")
         self._table = self._dynamodb.Table(Constants.DYNAMODB_TABLE.value)
 
-    def get_item(self, key: dict) -> dict | None:
+    def get_item(self, key: dict) -> Optional[dict]:
         """
         Retrieve an item from a DynamoDB table given the primary key(s),
         e.g. {"PartitionKey": "value", "SortKey": "value"}
@@ -40,17 +40,7 @@ class UserManager:
         key = {"PartitionKey": username, "SortKey": "PROFILE"}
         user_data = self.db_client.get_item(key)
         print(f"Retrieved user data from dynamodb: {user_data}")
-        if user_data:
-            join_date = user_data.get("join_date")
-            if join_date:
-                join_date = datetime.fromisoformat(join_date)
-            return User(
-                username=user_data.get("PartitionKey", ""),
-                email=user_data.get("email", ""),
-                role=user_data.get("role", ""),
-                join_date=join_date,
-            )
-        return None
+        return User.from_dynamodb_item(user_data) if user_data else None
 
     def create_user(self, user: User) -> User:
         """Create a new user in the database."""

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -94,6 +94,25 @@ class GameSessionManager:
         self.db_client.put_item(session_data)
         return session
 
+    def count_sessions_for_user(self, username: str) -> int:
+        """Count the number of sessions for a given user in the database."""
+        response = self.db_client.query_items(
+            key_condition_expression=Key("PartitionKey").eq(username)
+            & Key("SortKey").begins_with("SESSION"),
+            select="COUNT",
+        )
+        return response.get("Count", 0)
+
+    def get_total_annotations_for_user(self, username: str) -> int:
+        """Get the total number of annotations made by a user across all sessions."""
+        response = self.db_client.query_items(
+            key_condition_expression=Key("PartitionKey").eq(username)
+            & Key("SortKey").begins_with("SESSION"),
+            projection_expression="total_annotations",
+        )
+        items = response.get("Items", [])
+        total_annotations = sum(int(item.get("total_annotations", 0)) for item in items)
+        return total_annotations
 
 def initialize_db_managers() -> tuple[UserManager, GameSessionManager]:
     """Initialize and return database managers"""

--- a/game/utils/dynamodb.py
+++ b/game/utils/dynamodb.py
@@ -1,8 +1,9 @@
 """Utility clients for interacting with DynamoDB."""
 
-from typing import Optional
+from typing import Any, Optional
 
 import boto3
+from boto3.dynamodb.conditions import Key
 from config import Constants
 from models import GameSession, User
 
@@ -26,6 +27,28 @@ class DynamoDbClient:
     def put_item(self, item: dict) -> None:
         """Put an item into a DynamoDB table."""
         self._table.put_item(Item=item)
+
+    def query_items(
+        self,
+        key_condition_expression: Any,
+        filter_expression: Optional[Any] = None,
+        select: Optional[str] = None,
+        projection_expression: Optional[str] = None,
+    ) -> dict:
+        """Query items from a DynamoDB table using a key condition expression
+        and optional filter expression.
+        """
+        params = {
+            "KeyConditionExpression": key_condition_expression,
+        }
+        if filter_expression:
+            params["FilterExpression"] = filter_expression
+        if select:
+            params["Select"] = select
+        if projection_expression:
+            params["ProjectionExpression"] = projection_expression
+        response = self._table.query(**params)
+        return response
 
 
 class UserManager:

--- a/game/utils/game.py
+++ b/game/utils/game.py
@@ -84,6 +84,8 @@ def start_game():
         st.session_state.game_session = game_session
         # Start the game with first round
         game_session.start_game()
+        # Save the active game session to db
+        st.session_state.game_session_manager.create_session(game_session)
         start_round(1, game_options.get("time_per_round"))
 
 
@@ -97,6 +99,8 @@ def end_game():
             for summary in st.session_state.get("game_summary", {}).values()
         )
         st.session_state.game_session.end_game(total_annotations)
+        # Save the completed game session to db
+        st.session_state.game_session_manager.create_session(st.session_state.game_session)
     # TODO: delete the viewer instance if needed
     keys_to_clear = [
         "current_round",

--- a/game/utils/game.py
+++ b/game/utils/game.py
@@ -16,6 +16,7 @@ These should be cleared at the end of the game or when the user exits the game
 import streamlit as st
 from config import Constants
 from utils.neuroglancer import get_annotations_from_state
+from models import GameSession
 
 ######### Get game state from session_state #########
 
@@ -73,11 +74,29 @@ def start_game():
     """Initalize and start the first round of the game if not already started."""
     if "round_started" not in st.session_state:
         game_options = get_game_options_from_session_state()
+        # Create GameSession object
+        game_session = GameSession(
+            username=st.session_state.user.username,
+            game_mode=game_options.get("game_mode", ""),
+            num_rounds=game_options.get("num_rounds", 0),
+            time_per_round=game_options.get("time_per_round", 0),
+        )
+        st.session_state.game_session = game_session
+        # Start the game with first round
+        game_session.start_game()
         start_round(1, game_options.get("time_per_round"))
 
 
 def end_game():
     """Clear game state from session_state."""
+    # Mark the game session as ended
+    if "game_session" in st.session_state:
+        # NOTE: summary is only calculated at end of each round
+        total_annotations = sum(
+            summary["num_annotations"]
+            for summary in st.session_state.get("game_summary", {}).values()
+        )
+        st.session_state.game_session.end_game(total_annotations)
     # TODO: delete the viewer instance if needed
     keys_to_clear = [
         "current_round",
@@ -87,6 +106,7 @@ def end_game():
         "viewer_url",
         "game_summary",
         "game_options",
+        "game_session",
     ]
     for key in keys_to_clear:
         if key in st.session_state:

--- a/game/utils/game.py
+++ b/game/utils/game.py
@@ -89,7 +89,9 @@ def start_game():
         start_round(1, game_options.get("time_per_round"))
 
 
-def save_game(total_annotations: int = 0, end_game: bool = False, is_abandoned: bool = False):
+def save_game(
+    total_annotations: int = 0, end_game: bool = False, is_abandoned: bool = False
+):
     """
     Save the current game session to the database.
     Optionally also mark the game as ended or abandoned.
@@ -106,6 +108,7 @@ def save_game(total_annotations: int = 0, end_game: bool = False, is_abandoned: 
         st.session_state.game_session_manager.upsert_session(
             st.session_state.game_session
         )
+
 
 def clear_game():
     """Clear game state from session_state."""

--- a/game/utils/game.py
+++ b/game/utils/game.py
@@ -15,8 +15,8 @@ These should be cleared at the end of the game or when the user exits the game
 
 import streamlit as st
 from config import Constants
-from utils.neuroglancer import get_annotations_from_state
 from models import GameSession
+from utils.neuroglancer import get_annotations_from_state
 
 ######### Get game state from session_state #########
 
@@ -100,7 +100,9 @@ def end_game():
         )
         st.session_state.game_session.end_game(total_annotations)
         # Save the completed game session to db
-        st.session_state.game_session_manager.create_session(st.session_state.game_session)
+        st.session_state.game_session_manager.create_session(
+            st.session_state.game_session
+        )
     # TODO: delete the viewer instance if needed
     keys_to_clear = [
         "current_round",

--- a/game/utils/game.py
+++ b/game/utils/game.py
@@ -85,24 +85,30 @@ def start_game():
         # Start the game with first round
         game_session.start_game()
         # Save the active game session to db
-        st.session_state.game_session_manager.create_session(game_session)
+        st.session_state.game_session_manager.upsert_session(game_session)
         start_round(1, game_options.get("time_per_round"))
 
 
-def end_game():
-    """Clear game state from session_state."""
-    # Mark the game session as ended
+def save_game(total_annotations: int = 0, end_game: bool = False, is_abandoned: bool = False):
+    """
+    Save the current game session to the database.
+    Optionally also mark the game as ended or abandoned.
+    If game is abandoned, do not update total annotations.
+    """
     if "game_session" in st.session_state:
-        # NOTE: summary is only calculated at end of each round
-        total_annotations = sum(
-            summary["num_annotations"]
-            for summary in st.session_state.get("game_summary", {}).values()
-        )
-        st.session_state.game_session.end_game(total_annotations)
-        # Save the completed game session to db
-        st.session_state.game_session_manager.create_session(
+        if end_game and not is_abandoned:
+            st.session_state.game_session.end_game(total_annotations)
+        elif end_game and is_abandoned:
+            st.session_state.game_session.abandon_game()
+        else:
+            st.session_state.game_session.update_total_annotations(total_annotations)
+        # Save the updated game session to db
+        st.session_state.game_session_manager.upsert_session(
             st.session_state.game_session
         )
+
+def clear_game():
+    """Clear game state from session_state."""
     # TODO: delete the viewer instance if needed
     keys_to_clear = [
         "current_round",

--- a/game/utils/menu.py
+++ b/game/utils/menu.py
@@ -3,7 +3,7 @@
 import streamlit as st
 from config import Constants, Pages, UserRoles
 from models import User
-from utils.game import end_game
+from utils.game import clear_game, save_game
 
 
 def menu_with_redirect(show_game_menu: bool = False):
@@ -39,7 +39,9 @@ def _authenticated_menu(show_game_menu):
         if st.sidebar.button(
             "Exit Game", icon=":material/exit_to_app:", use_container_width=True
         ):
-            end_game()
+            # Ends any current game session and saves to db
+            save_game(end_game=True, is_abandoned=True)
+            clear_game()
             st.switch_page(Pages.HOME.value.link)
     else:
         # Nav menu: page links, logout


### PR DESCRIPTION
closes #36 

This PR:
- Implements GameSession class to model games. Adds methods to start/stop the game, and to convert between data model and Dynamodb DB item.
- Creates GameSessionManager to read/write game sessions to dynamodb
- Integrates with UI so that when the game start and stops, the game session info is saved to dynamodb
    - Game session info is saved at start, between rounds, at end, and if user abandons game
- Displays basic game stats in Account page: total games played, total annotations made

Example DynamoDb items for sortKey starts with "SESSION"
<img width="1553" height="297" alt="image" src="https://github.com/user-attachments/assets/65c414f6-b471-45d6-9c2b-ca8b1305e1f4" />

<img width="893" height="571" alt="image" src="https://github.com/user-attachments/assets/d08f3472-aa51-4d0c-8009-53bb8dad43ad" />

